### PR TITLE
Fixed Windows Phone bug: custom pickers not working

### DIFF
--- a/samples/extended/www/pickers.html
+++ b/samples/extended/www/pickers.html
@@ -1,17 +1,17 @@
-<ons-page>
-        <ons-list-header>Alternative Picker Configurations</ons-list-header>
-        <ons-scroller>
-            <ons-list>
-                <ons-list-item modifier="tappable" onclick="customPicker(0,0,0,0);">Fullscreen Picker</ons-list-item>
-                <ons-list-item modifier="tappable" onclick="customPicker(40,40,40,40)">Cropped Picker</ons-list-item>
-                <ons-list-item modifier="tappable" onclick="customPicker(40,0,40,0)">L/R Cropped Picker</ons-list-item>
-                <ons-list-item modifier="tappable" onclick="customPicker(1,60,1,60)">T/B Cropped Picker</ons-list-item>
-            </ons-list>
-            <rr />
-            <div ng-style="{'display': scannedCode === '' ? 'none' : 'block'}">
-                <div style="text-align:center">
-                        <span>Scanned Code: </span><span>{{scannedCode}}</span>
-                </div>
+<ons-page onclick="hide()">
+    <ons-list-header>Alternative Picker Configurations</ons-list-header>
+    <ons-scroller>
+        <ons-list id="pickerchoices">
+            <ons-list-item modifier="tappable">Fullscreen Picker</ons-list-item>
+            <ons-list-item modifier="tappable">Cropped Picker</ons-list-item>
+            <ons-list-item modifier="tappable">L/R Cropped Picker</ons-list-item>
+            <ons-list-item modifier="tappable">T/B Cropped Picker</ons-list-item>
+        </ons-list>
+        <br />
+        <div ng-style="{'display': scannedCode === '' ? 'none' : 'block'}">
+            <div style="text-align:center">
+                    <span>Scanned Code: </span><span>{{scannedCode}}</span>
             </div>
-        </ons-scroller>
-    </ons-page>
+        </div>
+    </ons-scroller>
+</ons-page>

--- a/samples/extended/www/pickers.js
+++ b/samples/extended/www/pickers.js
@@ -6,6 +6,11 @@
         } else {
             document.addEventListener('deviceready', $scope.stopPicker);
         }
+        var pickers = document.getElementById("pickerchoices");
+        pickers.children[0].onclick = function () { customPicker(0, 0, 0, 0); };
+        pickers.children[1].onclick = function () { customPicker(40, 40, 40, 40); };
+        pickers.children[2].onclick = function () { customPicker(40, 0, 40, 0); };
+        pickers.children[3].onclick = function () { customPicker(1, 60, 1, 60); };
     }
 
     exports.customPicker = function (marginLeft, marginTop, marginRight, marginBottom) {


### PR DESCRIPTION
The onclick wouldn't fire on windows phone.
By viewing the dom in realtime I realized angular changed the "onclick" directives to "x-onclick" directives.

See this issue: http://stackoverflow.com/questions/26055064/onclick-handlers-gets-prefixed-with-x-by-winjs

I am not sure why angular does this. IE doesn't play nice with it so I changed it.