### PR TITLE
respect FLAG_SECURE possibly set on cordova app

### DIFF
--- a/src/android/com/mirasense/scanditsdk/plugin/ScanditSDK.java
+++ b/src/android/com/mirasense/scanditsdk/plugin/ScanditSDK.java
@@ -191,11 +191,6 @@ OnScanListener, SearchBarBarcodePicker.ScanditSDKSearchBarListener {
             return;
         }
 
-        int flags = cordova.getActivity().getWindow().getAttributes().flags;
-        if ((flags & WindowManager.LayoutParams.FLAG_SECURE) != 0) {
-            options.putBoolean("secure", true);
-        }
-
         if (data.length() > 1) {
             // We extract all options and add them to the intent extra bundle.
             try {
@@ -288,6 +283,11 @@ OnScanListener, SearchBarBarcodePicker.ScanditSDKSearchBarListener {
                     }
 
                 } else {
+                    int flags = cordova.getActivity().getWindow().getAttributes().flags;
+                    if ((flags & WindowManager.LayoutParams.FLAG_SECURE) != 0) {
+                        options.putBoolean("secure", true);
+                    }
+
                     ScanditSDKResultRelay.setCallback(ScanditSDK.this);
                     Intent intent = new Intent(cordova.getActivity(), ScanditSDKActivity.class);
                     if (settings != null) {

--- a/src/android/com/mirasense/scanditsdk/plugin/ScanditSDK.java
+++ b/src/android/com/mirasense/scanditsdk/plugin/ScanditSDK.java
@@ -191,6 +191,11 @@ OnScanListener, SearchBarBarcodePicker.ScanditSDKSearchBarListener {
             return;
         }
 
+        int flags = cordova.getActivity().getWindow().getAttributes().flags;
+        if ((flags & WindowManager.LayoutParams.FLAG_SECURE) != 0) {
+            options.putBoolean("secure", true);
+        }
+
         if (data.length() > 1) {
             // We extract all options and add them to the intent extra bundle.
             try {

--- a/src/android/com/mirasense/scanditsdk/plugin/ScanditSDKActivity.java
+++ b/src/android/com/mirasense/scanditsdk/plugin/ScanditSDKActivity.java
@@ -94,6 +94,10 @@ public class ScanditSDKActivity extends Activity implements OnScanListener, Sear
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 
+        if (options.getBoolean("secure")) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
+
         ScanSettings scanSettings;
         if (mLegacyMode) {
             scanSettings = LegacySettingsParamParser.getSettings(options);


### PR DESCRIPTION
There was a problem when using this Plugin together with https://github.com/devgeeks/PrivacyScreenPlugin. The Privacyscreen Plugin was setting the FLAG_SECURE, which would cause a blank screen to be shown in the recent apps view.
Since this flag was not being set on the scanner overlay, a frozen image of the scanner view would be visible in the recent apps view and would stay there even after the overlay was closed.

My fix for this is to check whether the FLAG_SECURE is set on the original cordova window and apply this to the new overlay too. Since I only use the fullscreen overlay, I only applied it there, you might wanna check if this is necessary for the partial view.