### PR TITLE
Automatically add CameraUsageDescription on iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,12 @@
 	                       <feature name="SBSScanCasePlugin">          
 					<param name="ios-package" value="SBSScanCasePlugin"/>          
 				</feature>      
-		  </config-file>      
+		  </config-file>
+		  
+		  <!-- Declare Camera Usage for iOS10+ -->
+		  <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
+      			<string>Scandit</string>
+ 		  </config-file>
 
 		  <!-- Resource Bundle for Scandit SDK -->
 		  <resource-file src="src/ios/scanditsdk-community-ios_4.0.0/ScanditBarcodeScanner.bundle"/>	  


### PR DESCRIPTION
Add NSCameraUsageDescription to info.plist when adding the plugin to the project.
Resolves: https://scandit.zendesk.com/hc/en-us/articles/210073445-Cannot-run-the-app-it-crashes-with-iOS-10-what-can-I-do-